### PR TITLE
Remove custom font

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -28,7 +28,6 @@ body,
 .sidebar,
 #windows #form .input {
 	font-size: 14px;
-	font-family: "Roboto", "Noto Sans", "Noto Sans Emoji";
 }
 
 i.hostmask {


### PR DESCRIPTION
In the current version of The Lounge, this font doesn't load without extra hoops (see https://github.com/thelounge/lounge/pull/1266), which ends up being Times New Roman (at least on Mac, haven't checked somewhere else).

Also, now that the main repo uses native font stack (see https://github.com/thelounge/lounge/pull/1540), it is sensible to rely on it. This custom font could be re-added once support for custom fonts in themes is added to The Lounge (see https://github.com/thelounge/lounge/issues/1537) if you want.